### PR TITLE
Build Release Workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# ==========================================================
+# BUILD TIME ENV VARIABLES
+# ==========================================================
+
+# The SENTRY_AUTH_TOKEN variable is picked up by the Sentry Build Plugin.
+# It's used for authentication when uploading source maps.
+SENTRY_AUTH_TOKEN="sntrys_xxx"
+
+# ==========================================================
+# MAIN PROCESS RUNTIME ENV VARIABLES
+# ==========================================================
+MAIN_VITE_SENTRY_DSN="https://xxx@yyy.ingest.sentry.io/zzz"
+MAIN_VITE_SENTRY_CRASH_REPORT_DSN="https://xxx.ingest.sentry.io/api/yyy/minidump/?sentry_key=zzz"
+
+# ==========================================================
+# RENDERER PROCESS RUNTIME ENV VARIABLES
+# ==========================================================
+RENDERER_VITE_SENTRY_DSN="https://xxx@yyy.ingest.sentry.io/zzz"
+RENDERER_VITE_SENTRY_CRASH_REPORT_DSN="https://xxx.ingest.sentry.io/api/yyy/minidump/?sentry_key=zzz"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,16 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
+      - name: Create .env file from GitHub Secrets
+        run: |
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env
+
+          echo "MAIN_VITE_SENTRY_DSN=${{ secrets.MAIN_VITE_SENTRY_DSN }}" >> .env
+          echo "MAIN_VITE_SENTRY_CRASH_REPORT_DSN=${{ secrets.MAIN_VITE_SENTRY_CRASH_REPORT_DSN }}" >> .env
+
+          echo "RENDERER_VITE_SENTRY_DSN=${{ secrets.RENDERER_VITE_SENTRY_DSN }}" >> .env
+          echo "RENDERER_VITE_SENTRY_CRASH_REPORT_DSN=${{ secrets.RENDERER_VITE_SENTRY_CRASH_REPORT_DSN }}" >> .env
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,13 @@ env:
 
 jobs:
   build:
+    name: Build
     uses: ./.github/workflows/build.yml
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'node:path';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig, externalizeDepsPlugin, swcPlugin } from 'electron-vite';
@@ -37,11 +36,6 @@ export default defineConfig({
             vendor: ['lodash'],
           },
         },
-      },
-    },
-    resolve: {
-      alias: {
-        '@renderer': resolve('src/renderer/src'),
       },
     },
   },


### PR DESCRIPTION
### Changes

- Add example `.env` file
- Dynamically create `.env` file on CI server from GitHub secrets so available to the electron build and package routines