### PR TITLE
fix(build): look for artifacts in subfolders

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
+      "@semantic-release/npm",
       "@semantic-release/git",
       [
         "@semantic-release/github",

--- a/package.json
+++ b/package.json
@@ -66,16 +66,16 @@
         {
           "assets": [
             {
-              "path": "dist/phoenix-*.snap"
+              "path": "dist/**/phoenix-*.snap"
             },
             {
-              "path": "dist/phoenix-*.exe"
+              "path": "dist/**/phoenix-*.exe"
             },
             {
-              "path": "dist/phoenix-*.dmg"
+              "path": "dist/**/phoenix-*.dmg"
             },
             {
-              "path": "dist/phoenix-*.zip"
+              "path": "dist/**/phoenix-*.zip"
             }
           ]
         }


### PR DESCRIPTION
### Background

The `build` job creates platform-specific artifacts, and uploads them to platform-specific folders.

The `release` job should upload those artifacts to the GitHub Release so that people can easily download them.

### Changes

- Update glob pattern to look under subfolders of `dist`

### Example Artifact Directories

```sh
Run ls -R
.:
phoenix-app-macos-latest
phoenix-app-ubuntu-latest
phoenix-app-windows-latest

./phoenix-app-macos-latest:
phoenix-v0.0.1-mac-arm64.dmg
phoenix-v0.0.1-mac-arm64.zip
phoenix-v0.0.1-mac-x64.dmg
phoenix-v0.0.1-mac-x64.zip

./phoenix-app-ubuntu-latest:
phoenix-v0.0.1-linux-amd64.snap

./phoenix-app-windows-latest:
phoenix-v0.0.1-win-x64.exe
```