### PR TITLE
fix(build): pass secrets to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
+    secrets: inherit
 
   release:
     name: Release


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-of-jobsjob_idsecretsinherit