### PR TITLE
GitHub Workflow Merge Queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
       - opened
       - reopened
       - synchronize
+  # Validate pull request when added to a merge queue.
+  merge_group:
+    types:
+      - checks_requested
 
 # Allow at most one instance of this workflow to run at a time.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# Allow at most one instance of this workflow to run at a time.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # for checkout
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,6 +17,12 @@ on:
   pull_request:
     branches:
       - main
+  # Validate pull request when added to a merge queue.
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: Test
 
 on:
+  # Validate pull request when new commits are pushed.
   push:
+  # Validate pull request when added to a merge queue.
+  merge_group:
+    types:
+      - checks_requested
 
 env:
   # Don't install husky hooks


### PR DESCRIPTION
### Changes

- Mitigate race condition where two jobs are trying to perform semantic release at the same time.
- Trigger worksflows from [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)