### PR TITLE
Fix Game Stream Scrolling

### DIFF
--- a/electron/renderer/components/game/game-stream.tsx
+++ b/electron/renderer/components/game/game-stream.tsx
@@ -48,12 +48,12 @@ export const GameStream: React.FC<GameStreamProps> = (
   const appendGameLogLines = useCallback(
     (newLogLines: Array<GameLogLine>) => {
       setGameLogLines((oldLogLines: Array<GameLogLine>): Array<GameLogLine> => {
-      // Append new log line to the list.
-      newLogLines = oldLogLines.concat(newLogLines);
-      // Trim the back of the list to keep it within the scrollback buffer.
+        // Append new log line to the list.
+        newLogLines = oldLogLines.concat(newLogLines);
+        // Trim the back of the list to keep it within the scrollback buffer.
         newLogLines = newLogLines.slice(maxLines * -1);
-      return newLogLines;
-    });
+        return newLogLines;
+      });
     },
     [maxLines]
   );
@@ -96,31 +96,59 @@ export const GameStream: React.FC<GameStreamProps> = (
   // https://css-tricks.com/books/greatest-css-tricks/pin-scrolling-to-bottom/
   const scrollableRef = useRef<HTMLDivElement>(null);
   const scrollTargetRef = useRef<HTMLDivElement>(null);
-  const didInitialScrollRef = useRef<boolean>(false);
+  const observedTargetCountRef = useRef<number>(0);
 
   // The scroll behavior of `overflowAnchor: auto` doesn't take effect
   // to pin the content to the bottom until after an initial scroll event.
-  // Therefore, on each render we check if sufficient content has been
+  // Therefore, we observe the target to know if sufficient content has been
   // added to the scrollable element to warrant an initial scroll.
   // After that, the browser handles it automatically.
   useEffect(() => {
-    if (
-      // We haven't done an initial scroll yet.
-      !didInitialScrollRef.current &&
-      // There's something to scroll to.
-      scrollTargetRef.current &&
-      scrollableRef.current &&
-      // The scrollable element is scrollable.
-      scrollableRef.current.scrollHeight > scrollableRef.current.clientHeight
-    ) {
-      didInitialScrollRef.current = true;
-      scrollTargetRef.current.scrollIntoView({
-        behavior: 'instant',
-        block: 'end',
-        inline: 'nearest',
+    const callback: IntersectionObserverCallback = (
+      entries: Array<IntersectionObserverEntry>
+    ) => {
+      // The callback receives an entry for each observed target.
+      // In practice, we are only observing one target so we loop once.
+      entries.forEach((entry) => {
+        // When the component is first rendering, there is a period where
+        // there is no content and the scroll target is not visible.
+        // The observer invokes the callback that initial time, but we
+        // don't actually want to scroll to the bottom then, it's too soon.
+        // So we ignore the first invocation and only scroll on the second.
+        observedTargetCountRef.current += 1;
+        if (observedTargetCountRef.current <= 1) {
+          return;
+        }
+        // If the scroll target is visible, nothing to do yet.
+        if (entry.isIntersecting) {
+          return;
+        }
+        // The scroll target is now not visible, meaning that there's
+        // enough content on screen to cause the window to scroll.
+        // Perform our initial scroll to bottom and disconnect the observer.
+        // From now on, if the user scrolls away that's fine, we won't keep
+        // it pinned to bottom until they scroll back to bottom.
+        observer.disconnect();
+        scrollTargetRef.current?.scrollIntoView({
+          behavior: 'instant',
+          block: 'end',
+          inline: 'nearest',
+        });
       });
+    };
+
+    const observer = new IntersectionObserver(callback, {
+      threshold: 1.0,
+    });
+
+    if (scrollTargetRef.current) {
+      observer.observe(scrollTargetRef.current);
     }
-  });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   return (
     <EuiPanel

--- a/electron/renderer/components/grid/grid-item.tsx
+++ b/electron/renderer/components/grid/grid-item.tsx
@@ -48,8 +48,7 @@ export interface GridItemProps {
    */
   itemTitle: string;
   /**
-   * Handler when the user clicks the close button in the title bar.
-   * Passes the `itemId` of the grid item being closed.
+   * When the grid item is closed then notify the parent component.
    */
   onClose?: (item: GridItemInfo) => void;
   /**
@@ -277,30 +276,28 @@ export const GridItem: React.FC<GridItemProps> = memo(
     const getMouseGestureDragBindings = useDrag(dragHandler, dragOptions);
 
     // Styles for our drag and resize handle elements.
-    const handleStyles = useMemo(
-      () =>
-        css({
-          '.drag-handle': {
-            cursor: 'grab',
-          },
-          '.drag-handle:active': {
-            cursor: 'grabbing',
-            touchAction: 'none',
-          },
-          '.resize-handle': {
-            position: 'absolute',
-            bottom: -4,
-            right: -4,
-            width: 10,
-            height: 10,
-            cursor: 'nwse-resize',
-            touchAction: 'none',
-            backgroundColor: euiTheme.colors.mediumShade,
-            borderRadius: 5,
-          },
-        }),
-      [euiTheme]
-    );
+    const handleStyles = useMemo(() => {
+      return css({
+        '.drag-handle': {
+          cursor: 'grab',
+        },
+        '.drag-handle:active': {
+          cursor: 'grabbing',
+          touchAction: 'none',
+        },
+        '.resize-handle': {
+          position: 'absolute',
+          bottom: -4,
+          right: -4,
+          width: 10,
+          height: 10,
+          cursor: 'nwse-resize',
+          touchAction: 'none',
+          backgroundColor: euiTheme.colors.mediumShade,
+          borderRadius: 5,
+        },
+      });
+    }, [euiTheme]);
 
     return (
       <animated.div // react-spring element, works with the `useSpring` values
@@ -390,7 +387,7 @@ export const GridItem: React.FC<GridItemProps> = memo(
                   ref={resizeHandleRef}
                   className="resize-handle"
                   {...getMouseGestureDragBindings()}
-                ></div>
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiSplitPanel.Inner>


### PR DESCRIPTION
Was not reliably scrolling to bottom of stream content the first time the scroll-y bar showed.

The solutions on the interwebs from the past decade all said to compare scrollHeight and clientHeight but that no longer worked here.

Fix was to use observer to know when the element became visible (or not).