### PR TITLE
Support theme color modes changes

### DIFF
--- a/electron/renderer/components/game/game-stream-text.tsx
+++ b/electron/renderer/components/game/game-stream-text.tsx
@@ -1,5 +1,6 @@
-import { EuiText } from '@elastic/eui';
-import { memo } from 'react';
+import { EuiText, useEuiTheme } from '@elastic/eui';
+import { type SerializedStyles, css } from '@emotion/react';
+import { memo, useMemo } from 'react';
 import type { GameLogLine } from '../../types/game.types.jsx';
 
 export interface GameStreamTextProps {
@@ -9,24 +10,93 @@ export interface GameStreamTextProps {
 /**
  * We memoize the component per the event id because the log lines
  * are effectively immutable. This prevents unnecessary re-renders.
+ *
+ * One exception is when the theme color mode changes, at which point
+ * we do rerender all the log lines to apply the new styling effects.
  */
 export const GameStreamText: React.FC<GameStreamTextProps> = memo(
   (props: GameStreamTextProps) => {
     const { logLine } = props;
+
+    const { euiTheme } = useEuiTheme();
+
+    const textStyles = useMemo((): SerializedStyles => {
+      let fontSize = '14px';
+      let fontFamily = euiTheme.font.familySerif;
+      let fontWeight = euiTheme.font.weight.regular;
+      let fontColor = euiTheme.colors.text;
+
+      if (logLine.styles.outputClass === 'mono') {
+        fontFamily = euiTheme.font.familyCode;
+        fontSize = euiTheme.size.m;
+      }
+
+      if (logLine.styles.stylePreset === 'roomName') {
+        fontColor = euiTheme.colors.title;
+        fontWeight = euiTheme.font.weight.bold;
+      }
+
+      if (logLine.styles.bold === true) {
+        fontWeight = euiTheme.font.weight.bold;
+      }
+
+      if (logLine.styles.subdued === true) {
+        fontColor = euiTheme.colors.subduedText;
+      }
+
+      const textStyles = css({
+        fontSize,
+        fontFamily,
+        fontWeight,
+        color: fontColor,
+        lineHeight: 'initial',
+        paddingLeft: euiTheme.size.s,
+        paddingRight: euiTheme.size.s,
+      });
+
+      return textStyles;
+    }, [euiTheme, logLine.styles]);
 
     // We output the text using inner html because the text may contain tags.
     // For example, tags to highlight a single word or phrases.
     // If we output as `{logLine.text}` then those tags are escaped.
 
     return (
-      <EuiText id={logLine.eventId} css={logLine.styles}>
+      <EuiText id={logLine.eventId} css={textStyles}>
         <span dangerouslySetInnerHTML={{ __html: logLine.text }} />
       </EuiText>
     );
   },
   (oldProps, newProps) => {
-    return oldProps.logLine.eventId === newProps.logLine.eventId;
+    // Component will only rerender when this method returns false.
+    return isSameLogLine({
+      oldLogLine: oldProps.logLine,
+      newLogLine: newProps.logLine,
+    });
   }
 );
+
+/**
+ * For efficient memoization of the log lines, consider the log line the
+ * same if the event id and color mode are the same.
+ *
+ * Checking the color mode ensures that when the user changes the theme
+ * then all log lines are re-rendered. Otherwise the stream displays a
+ * mix of light and dark mode text, which is unintuitive and confusing.
+ */
+const isSameLogLine = (options: {
+  oldLogLine: GameLogLine;
+  newLogLine: GameLogLine;
+}): boolean => {
+  const { oldLogLine, newLogLine } = options;
+
+  const { eventId: oldEventId, styles: oldTheme } = oldLogLine;
+  const { eventId: newEventId, styles: newTheme } = newLogLine;
+
+  const isSameEventId = oldEventId === newEventId;
+  const isSameColorMode = oldTheme?.colorMode === newTheme?.colorMode;
+
+  return isSameEventId && isSameColorMode;
+};
 
 GameStreamText.displayName = 'GameStreamText';

--- a/electron/renderer/components/game/game-stream-text.tsx
+++ b/electron/renderer/components/game/game-stream-text.tsx
@@ -26,21 +26,21 @@ export const GameStreamText: React.FC<GameStreamTextProps> = memo(
       let fontWeight = euiTheme.font.weight.regular;
       let fontColor = euiTheme.colors.text;
 
-      if (logLine.styles.outputClass === 'mono') {
+      if (logLine.styles?.outputClass === 'mono') {
         fontFamily = euiTheme.font.familyCode;
         fontSize = euiTheme.size.m;
       }
 
-      if (logLine.styles.stylePreset === 'roomName') {
+      if (logLine.styles?.stylePreset === 'roomName') {
         fontColor = euiTheme.colors.title;
         fontWeight = euiTheme.font.weight.bold;
       }
 
-      if (logLine.styles.bold === true) {
+      if (logLine.styles?.bold === true) {
         fontWeight = euiTheme.font.weight.bold;
       }
 
-      if (logLine.styles.subdued === true) {
+      if (logLine.styles?.subdued === true) {
         fontColor = euiTheme.colors.subduedText;
       }
 

--- a/electron/renderer/components/game/game.utils.ts
+++ b/electron/renderer/components/game/game.utils.ts
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import * as rxjs from 'rxjs';
 import type { GameLogLine } from '../../types/game.types.jsx';
 
@@ -9,7 +8,6 @@ const emptyLogLine: GameLogLine = {
   eventId: '',
   streamId: '',
   text: '',
-  styles: css(),
 };
 
 /**

--- a/electron/renderer/types/game.types.ts
+++ b/electron/renderer/types/game.types.ts
@@ -29,7 +29,7 @@ export interface GameLogLine {
   /**
    * The text formatting to apply to the entire line.
    */
-  styles: {
+  styles?: {
     /**
      * The theme color mode to use (e.g. 'light' or 'dark').
      */

--- a/electron/renderer/types/game.types.ts
+++ b/electron/renderer/types/game.types.ts
@@ -1,4 +1,4 @@
-import type { SerializedStyles } from '@emotion/react';
+import type { EuiThemeColorMode } from '@elastic/eui';
 
 export interface Account {
   accountName: string;
@@ -23,13 +23,38 @@ export interface GameLogLine {
    */
   streamId: string;
   /**
-   * The text formatting to apply to this line.
-   */
-  styles: SerializedStyles;
-  /**
    * The text to display.
    */
   text: string;
+  /**
+   * The text formatting to apply to the entire line.
+   */
+  styles: {
+    /**
+     * The theme color mode to use (e.g. 'light' or 'dark').
+     */
+    colorMode: EuiThemeColorMode;
+    /**
+     * See `GameEventType.TEXT_OUTPUT_CLASS` for possible values.
+     * For example, 'mono' for monospaced text, or '' for normal text.
+     */
+    outputClass?: string;
+    /**
+     * See `GameEventType.TEXT_STYLE_PRESET` for possible values.
+     * For example, 'roomName' or 'roomDesc' or 'whisper', etc.
+     */
+    stylePreset?: string;
+    /**
+     * Use a bold font weight.
+     * Since this applies to the entire line, usually used for room titles.
+     */
+    bold?: boolean;
+    /**
+     * Use a subdued text color.
+     * Primarily used to style the command text we echo back to the user.
+     */
+    subdued?: boolean;
+  };
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@vitest/coverage-v8": "^3.0.2",
     "babel-loader": "^9.2.1",
     "concurrently": "^9.1.2",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "copy-webpack-plugin": "^12.0.2",
     "electron": "^33.3.1",
     "electron-builder": "^25.1.8",
@@ -155,7 +156,7 @@
       [
         "@semantic-release/release-notes-generator",
         {
-          "preset": "angular",
+          "preset": "conventionalcommits",
           "presetConfig": {
             "types": [
               {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7324,6 +7324,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"conventional-changelog-conventionalcommits@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "conventional-changelog-conventionalcommits@npm:8.0.0"
+  dependencies:
+    compare-func: "npm:^2.0.0"
+  checksum: 10c0/368ee2245094579b38e1beac110577f75d82ab341d1bc6943052d5243f8bacc9ea08222a91a595a17f5f4ccc321b926211da00dd25b43877a3c51d8218bc76f0
+  languageName: node
+  linkType: hard
+
 "conventional-changelog-writer@npm:^8.0.0":
   version: 8.0.0
   resolution: "conventional-changelog-writer@npm:8.0.0"
@@ -13802,6 +13811,7 @@ __metadata:
     babel-loader: "npm:^9.2.1"
     chalk: "npm:^5.4.1"
     concurrently: "npm:^9.1.2"
+    conventional-changelog-conventionalcommits: "npm:^8.0.0"
     copy-webpack-plugin: "npm:^12.0.2"
     dotenv: "npm:^16.4.7"
     dotenv-flow: "npm:^4.1.0"


### PR DESCRIPTION
Previously, when the user changes they theme color preference, the text in the game streams doesn't retroactively update. Only new text takes on the new theming.

This PR fixes that so that when the theme color changes then all game text updates, as the user would expect it to.