### PR TITLE
Display URLs inline in text

### DIFF
--- a/electron/common/game/types.ts
+++ b/electron/common/game/types.ts
@@ -77,8 +77,7 @@ export type GameEvent =
   | RoomGameEvent
   | ServerTimeGameEvent
   | RoundTimeGameEvent
-  | CastTimeGameEvent
-  | URLGameEvent;
+  | CastTimeGameEvent;
 
 export interface GameEventBase {
   /**
@@ -258,15 +257,6 @@ export interface CastTimeGameEvent extends GameEventBase {
   time: number;
 }
 
-/**
- * <a href='https://elanthipedia.play.net/'>Elanthipedia</a>
- */
-export interface URLGameEvent extends GameEventBase {
-  type: GameEventType.URL;
-  url: string; // e.g. 'https://elanthipedia.play.net/'
-  text: string; // e.g. 'Elanthipedia'
-}
-
 export enum GameEventType {
   /**
    * Text to display to the player.
@@ -358,10 +348,6 @@ export enum GameEventType {
    * the number of seconds to wait.
    */
   CAST_TIME = 'CAST_TIME',
-  /**
-   * URL link to display to the player.
-   */
-  URL = 'URL',
 }
 
 export enum IndicatorType {

--- a/electron/main/game/__tests__/game-parser.test.ts
+++ b/electron/main/game/__tests__/game-parser.test.ts
@@ -115,22 +115,13 @@ describe('game-parser', () => {
     });
 
     it('emits TextGameEvent (anchor link text)', () => {
-      gameSocketSubject$.next('Visit the <a href="#">play.net</a> website.\n');
+      gameSocketSubject$.next(
+        'Visit the <a href="https://play.net/dr">DragonRealms</a> website.\n'
+      );
 
       expectGameEvent({
         type: GameEventType.TEXT,
-        text: `Visit the `,
-      });
-
-      expectGameEvent({
-        type: GameEventType.URL,
-        text: `play.net`,
-        url: '#',
-      });
-
-      expectGameEvent({
-        type: GameEventType.TEXT,
-        text: ` website.\n`,
+        text: `Visit the <a href="https://play.net/dr" target="_blank">DragonRealms</a> website.\n`,
       });
     });
 

--- a/electron/main/initialize-app.ts
+++ b/electron/main/initialize-app.ts
@@ -167,9 +167,9 @@ export const initializeApp = async (): Promise<void> => {
   // https://www.electronjs.org/docs/latest/tutorial/security
   app.on('web-contents-created', (_, contents) => {
     const allowedDomains = [
-      /^(www\.)?github\.com$/i,
-      /^(www\.)?play\.net$/i,
-      /^elanthipedia\.play\.net$/i,
+      // https://regex101.com/r/pUmfMR/1
+      /^(.*\.)?github\.com$/i,
+      /^(.*\.)?play\.net$/i,
     ];
 
     const isAllowedDomain = (domain: string): boolean => {

--- a/electron/renderer/pages/game.tsx
+++ b/electron/renderer/pages/game.tsx
@@ -152,6 +152,14 @@ const GamePage: React.FC = (): ReactNode => {
           text: gameEvent.text,
         });
         break;
+      case GameEventType.URL:
+        gameLogLineSubject$.next({
+          eventId: gameEvent.eventId,
+          streamId: gameStreamIdRef.current,
+          styles: textStyles,
+          text: `<a href="${gameEvent.url}" target="_blank">${gameEvent.text}</a>`,
+        });
+        break;
       case GameEventType.EXPERIENCE:
         // TODO need to track a map of skill names to their latest event
         //      so that when we receive a new event we can update that skill

--- a/electron/renderer/pages/game.tsx
+++ b/electron/renderer/pages/game.tsx
@@ -152,14 +152,6 @@ const GamePage: React.FC = (): ReactNode => {
           text: gameEvent.text,
         });
         break;
-      case GameEventType.URL:
-        gameLogLineSubject$.next({
-          eventId: gameEvent.eventId,
-          streamId: gameStreamIdRef.current,
-          styles: textStyles,
-          text: `<a href="${gameEvent.url}" target="_blank">${gameEvent.text}</a>`,
-        });
-        break;
       case GameEventType.EXPERIENCE:
         // TODO need to track a map of skill names to their latest event
         //      so that when we receive a new event we can update that skill


### PR DESCRIPTION
Previously, URLs parsed from the game were displayed on their own lines. Now they'll appear in the same line as intended.