### PR TITLE
chore(build): locate artifacts in nested folders under 'dist'

### DIFF
--- a/scripts/update-version-file.sh
+++ b/scripts/update-version-file.sh
@@ -25,7 +25,7 @@ VERSION="${VERSION:-"${npm_package_version}"}"
 echo "export const VERSION = '${VERSION}';" > electron/common/version.ts
 
 # Rename dist files since they were built before the version was ticked
-for file in "$ROOT_DIR/dist"/*; do
+find "$ROOT_DIR/dist" -type f | while read -r file; do
   if [[ $file =~ (.*)-v[0-9]+\.[0-9]+\.[0-9]+-(.*) ]]; then
     new_file="${BASH_REMATCH[1]}-v${VERSION}-${BASH_REMATCH[2]}"
     mv "$file" "$new_file"


### PR DESCRIPTION
Example where GitHub Actions downloads the artifacts:

```shell
$ ls -r
.:
phoenix-app-macos-latest
phoenix-app-ubuntu-latest
phoenix-app-windows-latest

./phoenix-app-macos-latest:
phoenix-v1.20.2-mac-x64.dmg
phoenix-v1.20.2-mac-x64.zip

./phoenix-app-ubuntu-latest:
phoenix-v1.20.2-linux-amd64.deb

./phoenix-app-windows-latest:
phoenix-v1.20.2-win-x64.exe
```